### PR TITLE
Use userUrl and update Example Server

### DIFF
--- a/example.html
+++ b/example.html
@@ -11,19 +11,16 @@
 
     <script>
         function startFiling() {
-            // Get the token from the sample server
+            // Get the filing URL from the sample server
             fetch("http://localhost:3003/token")
                 .then(res => res.json())
                 .then(data => {
-                    const token = data["token"]
+                    const userUrl = data["userUrl"]
 
                     // Open the Column Tax module with these configs
                     ColumnTax.openModule({
-                        // Required: the token to authenticate the user
-                        token: token,
-
-                        // Required: the environment, one of "sandbox" or "production"
-                        environment: "sandbox",
+                        // Required: the filing url generated for the user
+                        userUrl: userUrl,
 
                         // Optional: onClose callback
                         onClose: () => {

--- a/server/app.js
+++ b/server/app.js
@@ -13,19 +13,19 @@ const clientSecret = '<client_secret>'
 
 const columnUrl = "https://sandbox.columnapi.com/v1/exp/initialize_tax_filing"
 
-// An endpoint to retrieve a user token from column tax. This token will be used in the
+// An endpoint to retrieve a user url from column tax. This url will be used in the
 // frontend application to open to column tax SDK.
 app.get('/token', (req, res) => {
     let apiKey = `${clientId}:${clientSecret}`;
     let auth = Buffer.from(apiKey).toString('base64')
 
     // An example user with mock data
-    let user = {
+    let data = {
         user_identifier: "unique_user_identifier",
-        email: "test@test.com",
+        user: { email: "test@test.com" },
     }
 
-    const body = JSON.stringify(user)
+    const body = JSON.stringify(data)
 
     const headers = {
         Authorization: `Basic ${auth}`,
@@ -34,7 +34,7 @@ app.get('/token', (req, res) => {
 
     axios.post(columnUrl, body, {headers})
         .then((body) => {
-            res.json({"token": body.data["user_token"]})
+            res.json({ "userUrl": body.data["user_url"] })
         })
         .catch((error) => {
             res.send("Bad API Keys or Wrong URL")

--- a/server/app.js
+++ b/server/app.js
@@ -13,8 +13,8 @@ const clientSecret = '<client_secret>'
 
 const columnUrl = "https://sandbox.columnapi.com/v1/exp/initialize_tax_filing"
 
-// An endpoint to retrieve a user url from column tax. This url will be used in the
-// frontend application to open to column tax SDK.
+// An endpoint to retrieve a user url from Column Tax. This url will be used in the
+// frontend application to open to Column Tax SDK.
 app.get('/token', (req, res) => {
     let apiKey = `${clientId}:${clientSecret}`;
     let auth = Buffer.from(apiKey).toString('base64')


### PR DESCRIPTION
## Description

Updates the sample web app to use `user_url` to open the SDK and also updates the sample backend to be up to date.

## Testing

Was able to play around with this successfully.